### PR TITLE
3.5.4

### DIFF
--- a/includes/Provider.php
+++ b/includes/Provider.php
@@ -295,6 +295,7 @@ class Provider
         $Parsedown = new Parsedown();
 
         $dateinput = preg_replace('/\\\s*$/m', ' ', $dateinput);
+        $dateinput = nl2br($dateinput);
 
         $html = $Parsedown->text($dateinput);
         return $this->sanitize_html_field($html);

--- a/includes/Provider/BITE.php
+++ b/includes/Provider/BITE.php
@@ -116,8 +116,8 @@ class BITE extends Provider
 
         // description
         $desc = '';
-        if ((isset($jobdata['custom']['einleitung'])) && (!empty($jobdata['custom']['einleitung']))) {
-            $desc .= $jobdata['custom']['einleitung'];
+        if ((isset($jobdata['custom']['einleitungstext'])) && (!empty($jobdata['custom']['einleitungstext']))) {
+            $desc .= $jobdata['custom']['einleitungstext'];
         }
         if ((isset($jobdata['custom']['aufgaben'])) && (!empty($jobdata['custom']['aufgaben']))) {
             $desc .= $jobdata['custom']['aufgaben'];
@@ -128,21 +128,29 @@ class BITE extends Provider
 
         $res['description'] = $desc;
 
-        if ((isset($jobdata['custom']['profil'])) && (!empty($jobdata['custom']['profil']))) {
-            $res['qualifications'] = '<p><strong>{{=const.title_qualifications_required}}:</strong></p>';
+        if (!empty($jobdata['custom']['profil'])) {
+            if (!empty($jobdata['custom']['job_experience']) || !empty($jobdata['custom']['job_qualifications_nth'])){
+                $res['qualifications'] = '<p><strong>{{=const.title_qualifications_required}}:</strong></p>';
+            }else{
+                $res['qualifications'] = '';
+            }
             $res['qualifications'] .= $jobdata['custom']['profil'];
         }
-        if ((isset($jobdata['custom']['job_experience'])) && (!empty($jobdata['custom']['job_experience']))) {
-            $res['qualifications'] .= '<p><strong>{{=const.title_qualifications_experience}}:</strong></p>';
+        if (!empty($jobdata['custom']['job_experience'])) {
+            if (!empty($jobdata['custom']['profil']) || !empty($jobdata['custom']['job_qualifications_nth'])){
+                $res['qualifications'] .= '<p><strong>{{=const.title_qualifications_experience}}:</strong></p>';
+            }
             $res['qualifications'] .= $jobdata['custom']['job_experience'];
         }
 
-        if ((isset($jobdata['custom']['job_qualifications_nth'])) && (!empty($jobdata['custom']['job_qualifications_nth']))) {
-            $res['qualifications'] .= '<p><strong>{{=const.title_qualifications_optional}}:</strong></p>';
+        if (!empty($jobdata['custom']['job_qualifications_nth'])) {
+            if (!empty($jobdata['custom']['profil']) || !empty($jobdata['custom']['job_experience'])){
+                $res['qualifications'] .= '<p><strong>{{=const.title_qualifications_optional}}:</strong></p>';
+            }
             $res['qualifications'] .= $jobdata['custom']['job_qualifications_nth'];
         }
 
-        if ((isset($jobdata['custom']['wir_bieten'])) && (!empty($jobdata['custom']['wir_bieten']))) {
+        if (!empty($jobdata['custom']['wir_bieten'])) {
             $res['jobBenefits'] = $jobdata['custom']['wir_bieten'];
         }
 
@@ -861,17 +869,14 @@ class BITE extends Provider
                         case 'active':
                             $value = $this->sanitize_bool($value);
                             break;
-
                         case 'id':
                             $value = $this->sanitize_bite_id($value);
                             break;
-
                         case 'anr':
                             $value = $this->sanitize_type($value, 'number');
                             break;
-
                         case 'aufgaben':
-                        case 'einleitung':
+                        case 'einleitungstext':
                         case 'stellenzusatz':
                         case 'profil':
                         case 'job_qualifications_nth':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrze-jobs",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Embedding job offers from job portal apis via shortcode",
   "main": "rrze-jobs.php",
   "textdomain": "rrze-jobs",

--- a/rrze-jobs.php
+++ b/rrze-jobs.php
@@ -4,7 +4,7 @@
 Plugin Name:     RRZE Jobs
 Plugin URI:      https://gitlab.rrze.fau.de/rrze-webteam/rrze-jobs
 Description:     Embedding job offers from job portal apis via shortcode
-Version:         3.5.3
+Version:         3.5.4
 Author:          RRZE Webteam
 Author URI:      https://blogs.fau.de/webworking/
 License:         GNU General Public License v3


### PR DESCRIPTION
Änderung nach Mail von Marcel 13.12.2022:

1. Feld "einleitung" wird jetzt nicht mehr verwendet, sondern stattdessen "einleitungstext"

2. ///n wird nun als <br> ausgeben

3. Nur wenn mindestens ein weiteres Feld zu den Unterteilungen von „Qualifikation“ ausgefüllt wurde, werden die Zwischenüberschrifen ausgegeben:

- Notwendige Qualifikationen
- Sonstige optionale Qualifikationen
- Wünschenswerte Qualifikationen